### PR TITLE
Support newer ezdxf syntax

### DIFF
--- a/odmt/odmt.py
+++ b/odmt/odmt.py
@@ -197,7 +197,7 @@ def dxf_merge(files, colors = range(0, 256), nolayer = False):
 
         # create layer
         if layer_num < 2 or nolayers == False:
-            dwg.layers.create(
+            dwg.layers.new(
                 name       = layer_name, 
                 dxfattribs = {'color': layer_color})
 

--- a/odmt/odmt.py
+++ b/odmt/odmt.py
@@ -197,9 +197,14 @@ def dxf_merge(files, colors = range(0, 256), nolayer = False):
 
         # create layer
         if layer_num < 2 or nolayers == False:
-            dwg.layers.new(
-                name       = layer_name, 
-                dxfattribs = {'color': layer_color})
+            try:
+                dwg.layers.create(
+                    name       = layer_name,
+                    dxfattribs = {'color': layer_color})
+            except AttributeError: # new syntax
+                dwg.layers.new(
+                    name       = layer_name,
+                    dxfattribs = {'color': layer_color})
 
         # parse file
         polylines = dxf_parse(file)


### PR DESCRIPTION
Everything works fine, but they renamed `create` to `new` when making new layers.

This supports both, with a try and `AttributeError` fallback to the new syntax